### PR TITLE
Feat/content builder

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,20 @@
+{
+    "mcpServers": {
+        "laravel-boost": {
+            "command": "php",
+            "args": [
+                "artisan",
+                "boost:mcp"
+            ]
+        },
+        "herd": {
+            "command": "php",
+            "args": [
+                "/Applications/Herd.app/Contents/Resources/herd-mcp.phar"
+            ],
+            "env": {
+                "SITE_PATH": "/Users/gamalaziz/Code/PHP/fullstack-porto"
+            }
+        }
+    }
+}

--- a/.cursor/skills/pest-testing/SKILL.md
+++ b/.cursor/skills/pest-testing/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: pest-testing
+description: "Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit, tests/Browser), or needs browser testing, smoke testing multiple pages for JS errors, or architecture tests. Covers: it()/expect() syntax, datasets, mocking, browser testing (visit/click/fill), smoke testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 4 features. Do not use for factories, seeders, migrations, controllers, models, or non-test PHP code."
+license: MIT
+metadata:
+  author: laravel
+---
+
+# Pest Testing 4
+
+## Documentation
+
+Use `search-docs` for detailed Pest 4 patterns and documentation.
+
+## Basic Usage
+
+### Creating Tests
+
+All tests must be written using Pest. Use `php artisan make:test --pest {name}`.
+
+### Test Organization
+
+- Unit/Feature tests: `tests/Feature` and `tests/Unit` directories.
+- Browser tests: `tests/Browser/` directory.
+- Do NOT remove tests without approval - these are core application code.
+
+### Basic Test Structure
+
+<!-- Basic Pest Test Example -->
+```php
+it('is true', function () {
+    expect(true)->toBeTrue();
+});
+```
+
+### Running Tests
+
+- Run minimal tests with filter before finalizing: `php artisan test --compact --filter=testName`.
+- Run all tests: `php artisan test --compact`.
+- Run file: `php artisan test --compact tests/Feature/ExampleTest.php`.
+
+## Assertions
+
+Use specific assertions (`assertSuccessful()`, `assertNotFound()`) instead of `assertStatus()`:
+
+<!-- Pest Response Assertion -->
+```php
+it('returns all', function () {
+    $this->postJson('/api/docs', [])->assertSuccessful();
+});
+```
+
+| Use | Instead of |
+|-----|------------|
+| `assertSuccessful()` | `assertStatus(200)` |
+| `assertNotFound()` | `assertStatus(404)` |
+| `assertForbidden()` | `assertStatus(403)` |
+
+## Mocking
+
+Import mock function before use: `use function Pest\Laravel\mock;`
+
+## Datasets
+
+Use datasets for repetitive tests (validation rules, etc.):
+
+<!-- Pest Dataset Example -->
+```php
+it('has emails', function (string $email) {
+    expect($email)->not->toBeEmpty();
+})->with([
+    'james' => 'james@laravel.com',
+    'taylor' => 'taylor@laravel.com',
+]);
+```
+
+## Pest 4 Features
+
+| Feature | Purpose |
+|---------|---------|
+| Browser Testing | Full integration tests in real browsers |
+| Smoke Testing | Validate multiple pages quickly |
+| Visual Regression | Compare screenshots for visual changes |
+| Test Sharding | Parallel CI runs |
+| Architecture Testing | Enforce code conventions |
+
+### Browser Test Example
+
+Browser tests run in real browsers for full integration testing:
+
+- Browser tests live in `tests/Browser/`.
+- Use Laravel features like `Event::fake()`, `assertAuthenticated()`, and model factories.
+- Use `RefreshDatabase` for clean state per test.
+- Interact with page: click, type, scroll, select, submit, drag-and-drop, touch gestures.
+- Test on multiple browsers (Chrome, Firefox, Safari) if requested.
+- Test on different devices/viewports (iPhone 14 Pro, tablets) if requested.
+- Switch color schemes (light/dark mode) when appropriate.
+- Take screenshots or pause tests for debugging.
+
+<!-- Pest Browser Test Example -->
+```php
+it('may reset the password', function () {
+    Notification::fake();
+
+    $this->actingAs(User::factory()->create());
+
+    $page = visit('/sign-in');
+
+    $page->assertSee('Sign In')
+        ->assertNoJavaScriptErrors()
+        ->click('Forgot Password?')
+        ->fill('email', 'nuno@laravel.com')
+        ->click('Send Reset Link')
+        ->assertSee('We have emailed your password reset link!');
+
+    Notification::assertSent(ResetPassword::class);
+});
+```
+
+### Smoke Testing
+
+Quickly validate multiple pages have no JavaScript errors:
+
+<!-- Pest Smoke Testing Example -->
+```php
+$pages = visit(['/', '/about', '/contact']);
+
+$pages->assertNoJavaScriptErrors()->assertNoConsoleLogs();
+```
+
+### Visual Regression Testing
+
+Capture and compare screenshots to detect visual changes.
+
+### Test Sharding
+
+Split tests across parallel processes for faster CI runs.
+
+### Architecture Testing
+
+Pest 4 includes architecture testing (from Pest 3):
+
+<!-- Architecture Test Example -->
+```php
+arch('controllers')
+    ->expect('App\Http\Controllers')
+    ->toExtendNothing()
+    ->toHaveSuffix('Controller');
+```
+
+## Common Pitfalls
+
+- Not importing `use function Pest\Laravel\mock;` before using mock
+- Using `assertStatus(200)` instead of `assertSuccessful()`
+- Forgetting datasets for repetitive validation tests
+- Deleting tests without approval
+- Forgetting `assertNoJavaScriptErrors()` in browser tests

--- a/.cursor/skills/tailwindcss-development/SKILL.md
+++ b/.cursor/skills/tailwindcss-development/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: tailwindcss-development
+description: "Always invoke when the user's message includes 'tailwind' in any form. Also invoke for: building responsive grid layouts (multi-column card grids, product grids), flex/grid page structures (dashboards with sidebars, fixed topbars, mobile-toggle navs), styling UI components (cards, tables, navbars, pricing sections, forms, inputs, badges), adding dark mode variants, fixing spacing or typography, and Tailwind v3/v4 work. The core use case: writing or fixing Tailwind utility classes in HTML templates (Blade, JSX, Vue). Skip for backend PHP logic, database queries, API routes, JavaScript with no HTML/CSS component, CSS file audits, build tool configuration, and vanilla CSS."
+license: MIT
+metadata:
+  author: laravel
+---
+
+# Tailwind CSS Development
+
+## Documentation
+
+Use `search-docs` for detailed Tailwind CSS v4 patterns and documentation.
+
+## Basic Usage
+
+- Use Tailwind CSS classes to style HTML. Check and follow existing Tailwind conventions in the project before introducing new patterns.
+- Offer to extract repeated patterns into components that match the project's conventions (e.g., Blade, JSX, Vue).
+- Consider class placement, order, priority, and defaults. Remove redundant classes, add classes to parent or child elements carefully to reduce repetition, and group elements logically.
+
+## Tailwind CSS v4 Specifics
+
+- Always use Tailwind CSS v4 and avoid deprecated utilities.
+- `corePlugins` is not supported in Tailwind v4.
+
+### CSS-First Configuration
+
+In Tailwind v4, configuration is CSS-first using the `@theme` directive — no separate `tailwind.config.js` file is needed:
+
+<!-- CSS-First Config -->
+```css
+@theme {
+  --color-brand: oklch(0.72 0.11 178);
+}
+```
+
+### Import Syntax
+
+In Tailwind v4, import Tailwind with a regular CSS `@import` statement instead of the `@tailwind` directives used in v3:
+
+<!-- v4 Import Syntax -->
+```diff
+- @tailwind base;
+- @tailwind components;
+- @tailwind utilities;
++ @import "tailwindcss";
+```
+
+### Replaced Utilities
+
+Tailwind v4 removed deprecated utilities. Use the replacements shown below. Opacity values remain numeric.
+
+| Deprecated | Replacement |
+|------------|-------------|
+| bg-opacity-* | bg-black/* |
+| text-opacity-* | text-black/* |
+| border-opacity-* | border-black/* |
+| divide-opacity-* | divide-black/* |
+| ring-opacity-* | ring-black/* |
+| placeholder-opacity-* | placeholder-black/* |
+| flex-shrink-* | shrink-* |
+| flex-grow-* | grow-* |
+| overflow-ellipsis | text-ellipsis |
+| decoration-slice | box-decoration-slice |
+| decoration-clone | box-decoration-clone |
+
+## Spacing
+
+Use `gap` utilities instead of margins for spacing between siblings:
+
+<!-- Gap Utilities -->
+```html
+<div class="flex gap-8">
+    <div>Item 1</div>
+    <div>Item 2</div>
+</div>
+```
+
+## Dark Mode
+
+If existing pages and components support dark mode, new pages and components must support it the same way, typically using the `dark:` variant:
+
+<!-- Dark Mode -->
+```html
+<div class="bg-white dark:bg-gray-900 text-gray-900 dark:text-white">
+    Content adapts to color scheme
+</div>
+```
+
+## Common Patterns
+
+### Flexbox Layout
+
+<!-- Flexbox Layout -->
+```html
+<div class="flex items-center justify-between gap-4">
+    <div>Left content</div>
+    <div>Right content</div>
+</div>
+```
+
+### Grid Layout
+
+<!-- Grid Layout -->
+```html
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <div>Card 1</div>
+    <div>Card 2</div>
+    <div>Card 3</div>
+</div>
+```
+
+## Common Pitfalls
+
+- Using deprecated v3 utilities (bg-opacity-*, flex-shrink-*, etc.)
+- Using `@tailwind` directives instead of `@import "tailwindcss"`
+- Trying to use `tailwind.config.js` instead of CSS `@theme` directive
+- Using margins for spacing between siblings instead of gap utilities
+- Forgetting to add dark mode variants when the project uses dark mode

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,401 @@
+<laravel-boost-guidelines>
+=== foundation rules ===
+
+# Laravel Boost Guidelines
+
+The Laravel Boost guidelines are specifically curated by Laravel maintainers for this application. These guidelines should be followed closely to ensure the best experience when building Laravel applications.
+
+## Foundational Context
+
+This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
+
+- php - 8.4
+- filament/filament (FILAMENT) - v5
+- laravel/framework (LARAVEL) - v12
+- laravel/prompts (PROMPTS) - v0
+- livewire/livewire (LIVEWIRE) - v4
+- laravel/boost (BOOST) - v2
+- laravel/mcp (MCP) - v0
+- laravel/pail (PAIL) - v1
+- laravel/pint (PINT) - v1
+- laravel/sail (SAIL) - v1
+- pestphp/pest (PEST) - v4
+- phpunit/phpunit (PHPUNIT) - v12
+- alpinejs (ALPINEJS) - v3
+- tailwindcss (TAILWINDCSS) - v4
+
+## Skills Activation
+
+This project has domain-specific skills available. You MUST activate the relevant skill whenever you work in that domain—don't wait until you're stuck.
+
+- `pest-testing` — Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit, tests/Browser), or needs browser testing, smoke testing multiple pages for JS errors, or architecture tests. Covers: it()/expect() syntax, datasets, mocking, browser testing (visit/click/fill), smoke testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 4 features. Do not use for factories, seeders, migrations, controllers, models, or non-test PHP code.
+- `tailwindcss-development` — Always invoke when the user's message includes 'tailwind' in any form. Also invoke for: building responsive grid layouts (multi-column card grids, product grids), flex/grid page structures (dashboards with sidebars, fixed topbars, mobile-toggle navs), styling UI components (cards, tables, navbars, pricing sections, forms, inputs, badges), adding dark mode variants, fixing spacing or typography, and Tailwind v3/v4 work. The core use case: writing or fixing Tailwind utility classes in HTML templates (Blade, JSX, Vue). Skip for backend PHP logic, database queries, API routes, JavaScript with no HTML/CSS component, CSS file audits, build tool configuration, and vanilla CSS.
+
+## Conventions
+
+- You must follow all existing code conventions used in this application. When creating or editing a file, check sibling files for the correct structure, approach, and naming.
+- Use descriptive names for variables and methods. For example, `isRegisteredForDiscounts`, not `discount()`.
+- Check for existing components to reuse before writing a new one.
+
+## Verification Scripts
+
+- Do not create verification scripts or tinker when tests cover that functionality and prove they work. Unit and feature tests are more important.
+
+## Application Structure & Architecture
+
+- Stick to existing directory structure; don't create new base folders without approval.
+- Do not change the application's dependencies without approval.
+
+## Frontend Bundling
+
+- If the user doesn't see a frontend change reflected in the UI, it could mean they need to run `npm run build`, `npm run dev`, or `composer run dev`. Ask them.
+
+## Documentation Files
+
+- You must only create documentation files if explicitly requested by the user.
+
+## Replies
+
+- Be concise in your explanations - focus on what's important rather than explaining obvious details.
+
+=== boost rules ===
+
+# Laravel Boost
+
+- Laravel Boost is an MCP server that comes with powerful tools designed specifically for this application. Use them.
+
+## Artisan Commands
+
+- Run Artisan commands directly via the command line (e.g., `php artisan route:list`, `php artisan tinker --execute "..."`).
+- Use `php artisan list` to discover available commands and `php artisan [command] --help` to check parameters.
+
+## URLs
+
+- Whenever you share a project URL with the user, you should use the `get-absolute-url` tool to ensure you're using the correct scheme, domain/IP, and port.
+
+## Debugging
+
+- Use the `database-query` tool when you only need to read from the database.
+- Use the `database-schema` tool to inspect table structure before writing migrations or models.
+- To execute PHP code for debugging, run `php artisan tinker --execute "your code here"` directly.
+- To read configuration values, read the config files directly or run `php artisan config:show [key]`.
+- To inspect routes, run `php artisan route:list` directly.
+- To check environment variables, read the `.env` file directly.
+
+## Reading Browser Logs With the `browser-logs` Tool
+
+- You can read browser logs, errors, and exceptions using the `browser-logs` tool from Boost.
+- Only recent browser logs will be useful - ignore old logs.
+
+## Searching Documentation (Critically Important)
+
+- Boost comes with a powerful `search-docs` tool you should use before trying other approaches when working with Laravel or Laravel ecosystem packages. This tool automatically passes a list of installed packages and their versions to the remote Boost API, so it returns only version-specific documentation for the user's circumstance. You should pass an array of packages to filter on if you know you need docs for particular packages.
+- Search the documentation before making code changes to ensure we are taking the correct approach.
+- Use multiple, broad, simple, topic-based queries at once. For example: `['rate limiting', 'routing rate limiting', 'routing']`. The most relevant results will be returned first.
+- Do not add package names to queries; package information is already shared. For example, use `test resource table`, not `filament 4 test resource table`.
+
+### Available Search Syntax
+
+1. Simple Word Searches with auto-stemming - query=authentication - finds 'authenticate' and 'auth'.
+2. Multiple Words (AND Logic) - query=rate limit - finds knowledge containing both "rate" AND "limit".
+3. Quoted Phrases (Exact Position) - query="infinite scroll" - words must be adjacent and in that order.
+4. Mixed Queries - query=middleware "rate limit" - "middleware" AND exact phrase "rate limit".
+5. Multiple Queries - queries=["authentication", "middleware"] - ANY of these terms.
+
+=== php rules ===
+
+# PHP
+
+- Always use curly braces for control structures, even for single-line bodies.
+
+## Constructors
+
+- Use PHP 8 constructor property promotion in `__construct()`.
+    - `public function __construct(public GitHub $github) { }`
+- Do not allow empty `__construct()` methods with zero parameters unless the constructor is private.
+
+## Type Declarations
+
+- Always use explicit return type declarations for methods and functions.
+- Use appropriate PHP type hints for method parameters.
+
+<!-- Explicit Return Types and Method Params -->
+```php
+protected function isAccessible(User $user, ?string $path = null): bool
+{
+    ...
+}
+```
+
+## Enums
+
+- Typically, keys in an Enum should be TitleCase. For example: `FavoritePerson`, `BestLake`, `Monthly`.
+
+## Comments
+
+- Prefer PHPDoc blocks over inline comments. Never use comments within the code itself unless the logic is exceptionally complex.
+
+## PHPDoc Blocks
+
+- Add useful array shape type definitions when appropriate.
+
+=== herd rules ===
+
+# Laravel Herd
+
+- The application is served by Laravel Herd and will be available at: `https?://[kebab-case-project-dir].test`. Use the `get-absolute-url` tool to generate valid URLs for the user.
+- You must not run any commands to make the site available via HTTP(S). It is always available through Laravel Herd.
+
+=== tests rules ===
+
+# Test Enforcement
+
+- Every change must be programmatically tested. Write a new test or update an existing test, then run the affected tests to make sure they pass.
+- Run the minimum number of tests needed to ensure code quality and speed. Use `php artisan test --compact` with a specific filename or filter.
+
+=== laravel/core rules ===
+
+# Do Things the Laravel Way
+
+- Use `php artisan make:` commands to create new files (i.e. migrations, controllers, models, etc.). You can list available Artisan commands using `php artisan list` and check their parameters with `php artisan [command] --help`.
+- If you're creating a generic PHP class, use `php artisan make:class`.
+- Pass `--no-interaction` to all Artisan commands to ensure they work without user input. You should also pass the correct `--options` to ensure correct behavior.
+
+## Database
+
+- Always use proper Eloquent relationship methods with return type hints. Prefer relationship methods over raw queries or manual joins.
+- Use Eloquent models and relationships before suggesting raw database queries.
+- Avoid `DB::`; prefer `Model::query()`. Generate code that leverages Laravel's ORM capabilities rather than bypassing them.
+- Generate code that prevents N+1 query problems by using eager loading.
+- Use Laravel's query builder for very complex database operations.
+
+### Model Creation
+
+- When creating new models, create useful factories and seeders for them too. Ask the user if they need any other things, using `php artisan make:model --help` to check the available options.
+
+### APIs & Eloquent Resources
+
+- For APIs, default to using Eloquent API Resources and API versioning unless existing API routes do not, then you should follow existing application convention.
+
+## Controllers & Validation
+
+- Always create Form Request classes for validation rather than inline validation in controllers. Include both validation rules and custom error messages.
+- Check sibling Form Requests to see if the application uses array or string based validation rules.
+
+## Authentication & Authorization
+
+- Use Laravel's built-in authentication and authorization features (gates, policies, Sanctum, etc.).
+
+## URL Generation
+
+- When generating links to other pages, prefer named routes and the `route()` function.
+
+## Queues
+
+- Use queued jobs for time-consuming operations with the `ShouldQueue` interface.
+
+## Configuration
+
+- Use environment variables only in configuration files - never use the `env()` function directly outside of config files. Always use `config('app.name')`, not `env('APP_NAME')`.
+
+## Testing
+
+- When creating models for tests, use the factories for the models. Check if the factory has custom states that can be used before manually setting up the model.
+- Faker: Use methods such as `$this->faker->word()` or `fake()->randomDigit()`. Follow existing conventions whether to use `$this->faker` or `fake()`.
+- When creating tests, make use of `php artisan make:test [options] {name}` to create a feature test, and pass `--unit` to create a unit test. Most tests should be feature tests.
+
+## Vite Error
+
+- If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `npm run build` or ask the user to run `npm run dev` or `composer run dev`.
+
+=== laravel/v12 rules ===
+
+# Laravel 12
+
+- CRITICAL: ALWAYS use `search-docs` tool for version-specific Laravel documentation and updated code examples.
+- Since Laravel 11, Laravel has a new streamlined file structure which this project uses.
+
+## Laravel 12 Structure
+
+- In Laravel 12, middleware are no longer registered in `app/Http/Kernel.php`.
+- Middleware are configured declaratively in `bootstrap/app.php` using `Application::configure()->withMiddleware()`.
+- `bootstrap/app.php` is the file to register middleware, exceptions, and routing files.
+- `bootstrap/providers.php` contains application specific service providers.
+- The `app/Console/Kernel.php` file no longer exists; use `bootstrap/app.php` or `routes/console.php` for console configuration.
+- Console commands in `app/Console/Commands/` are automatically available and do not require manual registration.
+
+## Database
+
+- When modifying a column, the migration must include all of the attributes that were previously defined on the column. Otherwise, they will be dropped and lost.
+- Laravel 12 allows limiting eagerly loaded records natively, without external packages: `$query->latest()->limit(10);`.
+
+### Models
+
+- Casts can and likely should be set in a `casts()` method on a model rather than the `$casts` property. Follow existing conventions from other models.
+
+=== pint/core rules ===
+
+# Laravel Pint Code Formatter
+
+- If you have modified any PHP files, you must run `vendor/bin/pint --dirty --format agent` before finalizing changes to ensure your code matches the project's expected style.
+- Do not run `vendor/bin/pint --test --format agent`, simply run `vendor/bin/pint --format agent` to fix any formatting issues.
+
+=== pest/core rules ===
+
+## Pest
+
+- This project uses Pest for testing. Create tests: `php artisan make:test --pest {name}`.
+- Run tests: `php artisan test --compact` or filter: `php artisan test --compact --filter=testName`.
+- Do NOT delete tests without approval.
+
+=== filament/filament rules ===
+
+## Filament
+
+- Filament is used by this application. Follow the existing conventions for how and where it is implemented.
+- Filament is a Server-Driven UI (SDUI) framework for Laravel that lets you define user interfaces in PHP using structured configuration objects. Built on Livewire, Alpine.js, and Tailwind CSS.
+- Use the `search-docs` tool for official documentation on Artisan commands, code examples, testing, relationships, and idiomatic practices. If `search-docs` is unavailable, refer to https://filamentphp.com/docs.
+
+### Artisan
+
+- Always use Filament-specific Artisan commands to create files. Find available commands with the `list-artisan-commands` tool, or run `php artisan --help`.
+- Always inspect required options before running a command, and always pass `--no-interaction`.
+
+### Patterns
+
+Always use static `make()` methods to initialize components. Most configuration methods accept a `Closure` for dynamic values.
+
+Use `Get $get` to read other form field values for conditional logic:
+
+<code-snippet name="Conditional form field visibility" lang="php">
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Components\Utilities\Get;
+
+Select::make('type')
+    ->options(CompanyType::class)
+    ->required()
+    ->live(),
+
+TextInput::make('company_name')
+    ->required()
+    ->visible(fn (Get $get): bool => $get('type') === 'business'),
+
+</code-snippet>
+
+Use `state()` with a `Closure` to compute derived column values:
+
+<code-snippet name="Computed table column value" lang="php">
+use Filament\Tables\Columns\TextColumn;
+
+TextColumn::make('full_name')
+    ->state(fn (User $record): string => "{$record->first_name} {$record->last_name}"),
+
+</code-snippet>
+
+Actions encapsulate a button with an optional modal form and logic:
+
+<code-snippet name="Action with modal form" lang="php">
+use Filament\Actions\Action;
+use Filament\Forms\Components\TextInput;
+
+Action::make('updateEmail')
+    ->schema([
+        TextInput::make('email')
+            ->email()
+            ->required(),
+    ])
+    ->action(fn (array $data, User $record) => $record->update($data))
+
+</code-snippet>
+
+### Testing
+
+Always authenticate before testing panel functionality. Filament uses Livewire, so use `Livewire::test()` or `livewire()` (available when `pestphp/pest-plugin-livewire` is in `composer.json`):
+
+<code-snippet name="Table test" lang="php">
+use function Pest\Livewire\livewire;
+
+livewire(ListUsers::class)
+    ->assertCanSeeTableRecords($users)
+    ->searchTable($users->first()->name)
+    ->assertCanSeeTableRecords($users->take(1))
+    ->assertCanNotSeeTableRecords($users->skip(1));
+
+</code-snippet>
+
+<code-snippet name="Create resource test" lang="php">
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Livewire\livewire;
+
+livewire(CreateUser::class)
+    ->fillForm([
+        'name' => 'Test',
+        'email' => 'test@example.com',
+    ])
+    ->call('create')
+    ->assertNotified()
+    ->assertRedirect();
+
+assertDatabaseHas(User::class, [
+    'name' => 'Test',
+    'email' => 'test@example.com',
+]);
+
+</code-snippet>
+
+<code-snippet name="Testing validation" lang="php">
+use function Pest\Livewire\livewire;
+
+livewire(CreateUser::class)
+    ->fillForm([
+        'name' => null,
+        'email' => 'invalid-email',
+    ])
+    ->call('create')
+    ->assertHasFormErrors([
+        'name' => 'required',
+        'email' => 'email',
+    ])
+    ->assertNotNotified();
+
+</code-snippet>
+
+<code-snippet name="Calling actions in pages" lang="php">
+use Filament\Actions\DeleteAction;
+use function Pest\Livewire\livewire;
+
+livewire(EditUser::class, ['record' => $user->id])
+    ->callAction(DeleteAction::class)
+    ->assertNotified()
+    ->assertRedirect();
+
+</code-snippet>
+
+<code-snippet name="Calling actions in tables" lang="php">
+use Filament\Actions\Testing\TestAction;
+use function Pest\Livewire\livewire;
+
+livewire(ListUsers::class)
+    ->callAction(TestAction::make('promote')->table($user), [
+        'role' => 'admin',
+    ])
+    ->assertNotified();
+
+</code-snippet>
+
+### Correct Namespaces
+
+- Form fields (`TextInput`, `Select`, etc.): `Filament\Forms\Components\`
+- Infolist entries (`TextEntry`, `IconEntry`, etc.): `Filament\Infolists\Components\`
+- Layout components (`Grid`, `Section`, `Fieldset`, `Tabs`, `Wizard`, etc.): `Filament\Schemas\Components\`
+- Schema utilities (`Get`, `Set`, etc.): `Filament\Schemas\Components\Utilities\`
+- Actions (`DeleteAction`, `CreateAction`, etc.): `Filament\Actions\`. Never use `Filament\Tables\Actions\`, `Filament\Forms\Actions\`, or any other sub-namespace for actions.
+- Icons: `Filament\Support\Icons\Heroicon` enum (e.g., `Heroicon::PencilSquare`)
+
+### Common Mistakes
+
+- **Never assume public file visibility.** File visibility is `private` by default. Always use `->visibility('public')` when public access is needed.
+- **Never assume full-width layout.** `Grid`, `Section`, and `Fieldset` do not span all columns by default. Explicitly set column spans when needed.
+
+</laravel-boost-guidelines>

--- a/app/Filament/Resources/Posts/Schemas/PostForm.php
+++ b/app/Filament/Resources/Posts/Schemas/PostForm.php
@@ -2,10 +2,15 @@
 
 namespace App\Filament\Resources\Posts\Schemas;
 
+use Filament\Forms\Components\Builder;
+use Filament\Forms\Components\Builder\Block;
+use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Str;
 
 class PostForm
@@ -17,24 +22,44 @@ class PostForm
                 TextInput::make('title')
                     ->required()
                     ->live(onBlur: true)
-                    ->afterStateUpdated(function ($state, $set, $get, $record = null): void {
-                        $currentSlug = $get('slug');
-                        $newSlug = Str::slug($state ?? '');
-                        $previousTitle = $record?->title;
-                        $previousAutoSlug = $previousTitle !== null ? Str::slug($previousTitle) : null;
-                        $shouldSet = $currentSlug === ''
-                            || ($previousAutoSlug !== null && $currentSlug === $previousAutoSlug);
-                        if ($shouldSet) {
-                            $set('slug', $newSlug);
-                        }
-                    }),
+                    ->afterStateUpdated(fn ($state, $set) => $set('slug', Str::slug((string) ($state ?? '')))),
                 TextInput::make('slug')
-                    ->required()
-                    ->unique(ignoreRecord: true)
-                    ->helperText('Auto-filled from title; you can edit manually.'),
+                    ->disabled()
+                    ->dehydrated(false)
+                    ->default(fn ($get) => Str::slug((string) ($get('title') ?? '')))
+                    ->helperText('Generated from title when you save.'),
                 Toggle::make('is_public'),
-                RichEditor::make('content')
-                    ->json()
+                Section::make('Content')
+                    ->schema([
+                        Builder::make('content')
+                            ->hiddenLabel()
+                            ->blocks([
+                                Block::make('paragraph')
+                                    ->label(fn (?array $state): string => $state === null ? 'Paragraph' : 'Paragraph')
+                                    ->icon(Heroicon::Bars3BottomLeft)
+                                    ->schema([
+                                        RichEditor::make('text')
+                                            ->disableToolbarButtons([
+                                                'attachFiles',
+                                            ])
+                                            ->hiddenLabel(),
+                                    ]),
+                                Block::make('image')
+                                    ->label('Image')
+                                    ->icon(Heroicon::Photo)
+                                    ->schema([
+                                        FileUpload::make('image')
+                                            ->hiddenLabel()
+                                            ->directory('post-images')
+                                            ->visibility('public')
+                                            ->image()
+                                            ->imageEditor(),
+                                    ]),
+                            ])
+                            ->blockNumbers()
+                            ->blockIcons()
+                            ->columnSpanFull(),
+                    ])
                     ->columnSpanFull(),
             ]);
     }

--- a/app/Filament/Resources/Projects/Schemas/ProjectForm.php
+++ b/app/Filament/Resources/Projects/Schemas/ProjectForm.php
@@ -2,11 +2,15 @@
 
 namespace App\Filament\Resources\Projects\Schemas;
 
+use Filament\Forms\Components\Builder;
+use Filament\Forms\Components\Builder\Block;
 use Filament\Forms\Components\FileUpload;
-use Filament\Forms\Components\KeyValue;
+use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Str;
 
 class ProjectForm
@@ -20,10 +24,41 @@ class ProjectForm
                     ->live(onBlur: true)
                     ->afterStateUpdated(fn ($state, $set) => $set('slug', Str::slug($state ?? ''))),
                 TextInput::make('slug')
-                    ->required()
-                    ->unique(ignoreRecord: true)
-                    ->helperText('Auto-filled from title; you can edit manually.'),
-                KeyValue::make('description')
+                    ->disabled()
+                    ->dehydrated(false)
+                    ->default(fn ($get) => Str::slug((string) ($get('title') ?? '')))
+                    ->helperText('Generated from title when you save.'),
+                Section::make('Description')
+                    ->schema([
+                        Builder::make('description')
+                            ->hiddenLabel()
+                            ->blocks([
+                                Block::make('paragraph')
+                                    ->label('Paragraph')
+                                    ->icon(Heroicon::Bars3BottomLeft)
+                                    ->schema([
+                                        RichEditor::make('text')
+                                            ->disableToolbarButtons([
+                                                'attachFiles',
+                                            ])
+                                            ->hiddenLabel(),
+                                    ]),
+                                Block::make('image')
+                                    ->label('Image')
+                                    ->icon(Heroicon::Photo)
+                                    ->schema([
+                                        FileUpload::make('image')
+                                            ->hiddenLabel()
+                                            ->directory('project-description-images')
+                                            ->visibility('public')
+                                            ->image()
+                                            ->imageEditor(),
+                                    ]),
+                            ])
+                            ->blockNumbers()
+                            ->blockIcons()
+                            ->columnSpanFull(),
+                    ])
                     ->columnSpanFull(),
                 TextInput::make('project_url')
                     ->url()

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
 
 class Post extends Model
 {
@@ -21,6 +22,20 @@ class Post extends Model
     protected $casts = [
         'content' => 'array',
     ];
+
+    protected static function booted(): void
+    {
+        static::saving(function (Post $post): void {
+            if (filled($post->title) && (string) $post->slug === '') {
+                $base = Str::slug($post->title);
+                $post->slug = $base;
+                $count = 0;
+                while (static::query()->where('slug', $post->slug)->when($post->exists, fn ($q) => $q->whereKeyNot($post->getKey()))->exists()) {
+                    $post->slug = $base . '-' . (++$count);
+                }
+            }
+        });
+    }
 
     public function getRouteKeyName(): string
     {

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
 
 class Project extends Model
 {
@@ -26,6 +27,20 @@ class Project extends Model
     protected $casts = [
         'description' => 'array',
     ];
+
+    protected static function booted(): void
+    {
+        static::saving(function (Project $project): void {
+            if (filled($project->title) && (string) $project->slug === '') {
+                $base = Str::slug($project->title);
+                $project->slug = $base;
+                $count = 0;
+                while (static::query()->where('slug', $project->slug)->when($project->exists, fn ($q) => $q->whereKeyNot($project->getKey()))->exists()) {
+                    $project->slug = $base.'-'.(++$count);
+                }
+            }
+        });
+    }
 
     public function getRouteKeyName(): string
     {

--- a/app/Support/PostContentSanitizer.php
+++ b/app/Support/PostContentSanitizer.php
@@ -10,7 +10,8 @@ class PostContentSanitizer
     private static ?HtmlSanitizer $sanitizer = null;
 
     /**
-     * Return safe HTML for display from post content (TipTap JSON array or HTML string).
+     * Return safe HTML for display from post content.
+     * Supports: Filament Builder blocks (array of { type, data }), TipTap JSON doc, or HTML string.
      */
     public static function sanitize(array|string|null $content): string
     {
@@ -19,10 +20,102 @@ class PostContentSanitizer
         }
 
         $html = \is_array($content)
-            ? self::tiptapJsonToHtml($content)
+            ? self::arrayContentToHtml($content)
             : (string) $content;
 
         return self::sanitizer()->sanitize($html);
+    }
+
+    /**
+     * Detect format and convert array content to HTML (builder blocks or TipTap doc).
+     */
+    private static function arrayContentToHtml(array $content): string
+    {
+        if (self::isBuilderBlocks($content)) {
+            return self::builderBlocksToHtml($content);
+        }
+
+        return self::tiptapJsonToHtml($content);
+    }
+
+    /**
+     * Check if array is Filament Builder format: list of items with 'type' and 'data' keys.
+     */
+    private static function isBuilderBlocks(array $content): bool
+    {
+        if ($content === []) {
+            return false;
+        }
+        $first = reset($content);
+        if (!\is_array($first)) {
+            return false;
+        }
+        return \array_key_exists('type', $first) && \array_key_exists('data', $first);
+    }
+
+    /**
+     * Render Filament Builder blocks (paragraph, image) to HTML.
+     */
+    private static function builderBlocksToHtml(array $blocks): string
+    {
+        $out = '';
+        foreach ($blocks as $item) {
+            if (!\is_array($item)) {
+                continue;
+            }
+            $type = $item['type'] ?? '';
+            $data = \is_array($item['data'] ?? null) ? $item['data'] : [];
+            $out .= self::builderBlockToHtml($type, $data);
+        }
+
+        return $out;
+    }
+
+    private static function builderBlockToHtml(string $type, array $data): string
+    {
+        return match ($type) {
+            'paragraph' => self::builderParagraphToHtml($data),
+            'image' => self::builderImageToHtml($data),
+            default => '',
+        };
+    }
+
+    private static function builderParagraphToHtml(array $data): string
+    {
+        $text = $data['text'] ?? null;
+        if ($text === null || $text === '') {
+            return '';
+        }
+        if (\is_string($text)) {
+            return self::sanitizer()->sanitize('<p>' . $text . '</p>');
+        }
+        if (\is_array($text)) {
+            $inner = self::tiptapJsonToHtml($text);
+            if ($inner === '') {
+                return '';
+            }
+            return self::sanitizer()->sanitize($inner);
+        }
+
+        return '';
+    }
+
+    private static function builderImageToHtml(array $data): string
+    {
+        $image = $data['image'] ?? null;
+        if ($image === null || $image === '') {
+            return '';
+        }
+        $url = \is_array($image) ? ($image[0] ?? '') : (string) $image;
+        if ($url === '') {
+            return '';
+        }
+        if (!str_starts_with($url, 'http') && !str_starts_with($url, '/')) {
+            $url = \Illuminate\Support\Facades\Storage::url($url);
+        }
+        $alt = \is_string($data['alt'] ?? null) ? $data['alt'] : '';
+
+        return '<figure class="my-4"><img src="' . \e($url) . '" alt="' . \e($alt) . '" class="max-w-full h-auto rounded-lg" loading="lazy">' . ($alt !== '' ? '<figcaption class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">' . \e($alt) . '</figcaption>' : '') . '</figure>';
     }
 
     private static function sanitizer(): HtmlSanitizer

--- a/app/Support/PostContentSanitizer.php
+++ b/app/Support/PostContentSanitizer.php
@@ -2,6 +2,7 @@
 
 namespace App\Support;
 
+use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 
@@ -41,15 +42,16 @@ class PostContentSanitizer
     /**
      * Check if array is Filament Builder format: list of items with 'type' and 'data' keys.
      */
-    private static function isBuilderBlocks(array $content): bool
+    public static function isBuilderBlocks(array $content): bool
     {
         if ($content === []) {
             return false;
         }
         $first = reset($content);
-        if (!\is_array($first)) {
+        if (! \is_array($first)) {
             return false;
         }
+
         return \array_key_exists('type', $first) && \array_key_exists('data', $first);
     }
 
@@ -60,7 +62,7 @@ class PostContentSanitizer
     {
         $out = '';
         foreach ($blocks as $item) {
-            if (!\is_array($item)) {
+            if (! \is_array($item)) {
                 continue;
             }
             $type = $item['type'] ?? '';
@@ -87,13 +89,14 @@ class PostContentSanitizer
             return '';
         }
         if (\is_string($text)) {
-            return self::sanitizer()->sanitize('<p>' . $text . '</p>');
+            return self::sanitizer()->sanitize('<p>'.$text.'</p>');
         }
         if (\is_array($text)) {
             $inner = self::tiptapJsonToHtml($text);
             if ($inner === '') {
                 return '';
             }
+
             return self::sanitizer()->sanitize($inner);
         }
 
@@ -110,19 +113,19 @@ class PostContentSanitizer
         if ($url === '') {
             return '';
         }
-        if (!str_starts_with($url, 'http') && !str_starts_with($url, '/')) {
-            $url = \Illuminate\Support\Facades\Storage::url($url);
+        if (! str_starts_with($url, 'http') && ! str_starts_with($url, '/')) {
+            $url = Storage::url($url);
         }
         $alt = \is_string($data['alt'] ?? null) ? $data['alt'] : '';
 
-        return '<figure class="my-4"><img src="' . \e($url) . '" alt="' . \e($alt) . '" class="max-w-full h-auto rounded-lg" loading="lazy">' . ($alt !== '' ? '<figcaption class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">' . \e($alt) . '</figcaption>' : '') . '</figure>';
+        return '<figure class="my-4"><img src="'.\e($url).'" alt="'.\e($alt).'" class="max-w-full h-auto rounded-lg" loading="lazy">'.($alt !== '' ? '<figcaption class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">'.\e($alt).'</figcaption>' : '').'</figure>';
     }
 
     private static function sanitizer(): HtmlSanitizer
     {
         if (self::$sanitizer === null) {
             self::$sanitizer = new HtmlSanitizer(
-                (new HtmlSanitizerConfig())
+                (new HtmlSanitizerConfig)
                     ->allowSafeElements()
                     ->allowRelativeLinks()
             );
@@ -145,14 +148,14 @@ class PostContentSanitizer
             $html = e((string) $text);
             $marks = \is_array($node['marks'] ?? null) ? $node['marks'] : [];
             foreach ($marks as $mark) {
-                if (!\is_array($mark)) {
+                if (! \is_array($mark)) {
                     continue;
                 }
                 $markType = $mark['type'] ?? '';
                 $html = match ($markType) {
                     'bold' => "<strong>{$html}</strong>",
                     'italic' => "<em>{$html}</em>",
-                    'link' => '<a href="' . \e(self::linkHrefFromMark($mark)) . '">' . $html . '</a>',
+                    'link' => '<a href="'.\e(self::linkHrefFromMark($mark)).'">'.$html.'</a>',
                     'code' => "<code>{$html}</code>",
                     'strike' => "<s>{$html}</s>",
                     'underline' => "<u>{$html}</u>",
@@ -189,7 +192,7 @@ class PostContentSanitizer
     private static function linkHrefFromMark(array $mark): string
     {
         $attrs = $mark['attrs'] ?? null;
-        if (!\is_array($attrs)) {
+        if (! \is_array($attrs)) {
             return '#';
         }
         $href = $attrs['href'] ?? null;

--- a/app/View/Components/Ui/Button.php
+++ b/app/View/Components/Ui/Button.php
@@ -49,7 +49,7 @@ class Button extends Component
     public function isBuiltInTrailingIcon(): bool
     {
         return $this->iconTrailing !== null
-            && in_array($this->iconTrailing, self::BUILT_IN_TRAILING_ICONS, true);
+            && \in_array($this->iconTrailing, self::BUILT_IN_TRAILING_ICONS, true);
     }
 
     /**
@@ -113,7 +113,7 @@ class Button extends Component
      */
     public function insetClasses(): string
     {
-        if (! $this->inset || ! in_array($this->variant, ['ghost', 'subtle'], true)) {
+        if (!$this->inset || !in_array($this->variant, ['ghost', 'subtle'], true)) {
             return '';
         }
 

--- a/app/View/Components/Ui/Link.php
+++ b/app/View/Components/Ui/Link.php
@@ -4,6 +4,7 @@ namespace App\View\Components\Ui;
 
 use Closure;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Str;
 use Illuminate\View\Component;
 
 class Link extends Component
@@ -13,18 +14,74 @@ class Link extends Component
      *
      * @param  string  $href  The URL the link points to. Required when as="a".
      * @param  string  $variant  Link style: default, ghost, subtle. Default: default.
-     * @param  bool  $external  If true, open in a new tab (target="_blank" rel="noopener noreferrer").
+     * @param  bool|null  $external  If true, open in new tab. If null, inferred from href (same-origin = internal).
      * @param  string  $as  HTML tag: a or button. Default: a.
      */
     public function __construct(
         public string $href = '#',
         public string $variant = 'default',
-        public bool $external = false,
+        public ?bool $external = null,
         public string $as = 'a',
     ) {
         if (! in_array($this->as, ['a', 'button'], true)) {
             $this->as = 'a';
         }
+    }
+
+    public function isExternal(): bool
+    {
+        if ($this->external !== null) {
+            return $this->external;
+        }
+
+        return ! $this->isInternalUrl($this->href);
+    }
+
+    /**
+     * Href to render. Internal links are normalized to relative paths so wire:navigate intercepts them.
+     */
+    public function renderedHref(): string
+    {
+        if (! $this->isExternal() && Str::startsWith($this->href, ['http://', 'https://'])) {
+            $parsed = parse_url($this->href);
+            $path = $parsed['path'] ?? '/';
+            $query = isset($parsed['query']) ? '?'.$parsed['query'] : '';
+            $fragment = isset($parsed['fragment']) ? '#'.$parsed['fragment'] : '';
+
+            return $path.$query.$fragment;
+        }
+
+        return $this->href;
+    }
+
+    protected function isInternalUrl(string $href): bool
+    {
+        if ($href === '' || $href === '#') {
+            return true;
+        }
+
+        if (! Str::startsWith($href, ['http://', 'https://'])) {
+            return true;
+        }
+
+        $appUrl = rtrim(config('app.url'), '/');
+        $parsed = parse_url($href);
+
+        $schemePart = $parsed['scheme'] ?? '';
+        $scheme = "{$schemePart}://";
+        $host = $parsed['host'] ?? '';
+        $port = isset($parsed['port']) ? ":{$parsed['port']}" : '';
+        $origin = "{$scheme}{$host}{$port}";
+
+        $appScheme = parse_url($appUrl, PHP_URL_SCHEME);
+        $appHost = parse_url($appUrl, PHP_URL_HOST);
+        $appOrigin = "{$appScheme}://{$appHost}";
+        $appPort = parse_url($appUrl, PHP_URL_PORT);
+        if ($appPort !== null) {
+            $appOrigin .= ":{$appPort}";
+        }
+
+        return Str::lower($origin) === Str::lower($appOrigin);
     }
 
     public function isButton(): bool

--- a/boost.json
+++ b/boost.json
@@ -1,0 +1,17 @@
+{
+    "agents": [
+        "cursor"
+    ],
+    "guidelines": true,
+    "herd_mcp": true,
+    "mcp": true,
+    "nightwatch_mcp": false,
+    "packages": [
+        "filament/filament"
+    ],
+    "sail": false,
+    "skills": [
+        "pest-testing",
+        "tailwindcss-development"
+    ]
+}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,10 @@
     "name": "laravel/laravel",
     "type": "project",
     "description": "The skeleton application for the Laravel framework.",
-    "keywords": ["laravel", "framework"],
+    "keywords": [
+        "laravel",
+        "framework"
+    ],
     "license": "MIT",
     "require": {
         "php": "^8.2",
@@ -15,6 +18,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",
+        "laravel/boost": "^2.3",
         "laravel/pail": "^1.2.2",
         "laravel/pint": "^1.24",
         "laravel/sail": "^1.41",
@@ -58,7 +62,8 @@
             "@php artisan filament:upgrade"
         ],
         "post-update-cmd": [
-            "@php artisan vendor:publish --tag=laravel-assets --ansi --force"
+            "@php artisan vendor:publish --tag=laravel-assets --ansi --force",
+            "@php artisan boost:update --ansi"
         ],
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a729f5dfe2d1cda4452cfb534f20ca91",
+    "content-hash": "bdf1c028b8fb55f7094134cfb77539f5",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -8568,6 +8568,145 @@
             "time": "2025-03-19T14:43:43+00:00"
         },
         {
+            "name": "laravel/boost",
+            "version": "v2.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/boost.git",
+                "reference": "9e3dd5f05b59394e463e78853067dc36c63a0394"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/boost/zipball/9e3dd5f05b59394e463e78853067dc36c63a0394",
+                "reference": "9e3dd5f05b59394e463e78853067dc36c63a0394",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^7.9",
+                "illuminate/console": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/contracts": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/routing": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/support": "^11.45.3|^12.41.1|^13.0",
+                "laravel/mcp": "^0.5.1|^0.6.0",
+                "laravel/prompts": "^0.3.10",
+                "laravel/roster": "^0.5.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.27.0",
+                "mockery/mockery": "^1.6.12",
+                "orchestra/testbench": "^9.15.0|^10.6|^11.0",
+                "pestphp/pest": "^2.36.0|^3.8.4|^4.1.5",
+                "phpstan/phpstan": "^2.1.27",
+                "rector/rector": "^2.1"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Boost\\BoostServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Boost\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Laravel Boost accelerates AI-assisted development by providing the essential context and structure that AI needs to generate high-quality, Laravel-specific code.",
+            "homepage": "https://github.com/laravel/boost",
+            "keywords": [
+                "ai",
+                "dev",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/boost/issues",
+                "source": "https://github.com/laravel/boost"
+            },
+            "time": "2026-03-17T16:42:14+00:00"
+        },
+        {
+            "name": "laravel/mcp",
+            "version": "v0.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/mcp.git",
+                "reference": "8a2c97ec1184e16029080e3f6172a7ca73de4df9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/mcp/zipball/8a2c97ec1184e16029080e3f6172a7ca73de4df9",
+                "reference": "8a2c97ec1184e16029080e3f6172a7ca73de4df9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "illuminate/console": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/container": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/contracts": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/http": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/json-schema": "^12.41.1|^13.0",
+                "illuminate/routing": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/support": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/validation": "^11.45.3|^12.41.1|^13.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.20",
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "pestphp/pest": "^3.8.5|^4.3.2",
+                "phpstan/phpstan": "^2.1.27",
+                "rector/rector": "^2.2.4"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Mcp": "Laravel\\Mcp\\Server\\Facades\\Mcp"
+                    },
+                    "providers": [
+                        "Laravel\\Mcp\\Server\\McpServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Mcp\\": "src/",
+                    "Laravel\\Mcp\\Server\\": "src/Server/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Rapidly build MCP servers for your Laravel applications.",
+            "homepage": "https://github.com/laravel/mcp",
+            "keywords": [
+                "laravel",
+                "mcp"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/mcp/issues",
+                "source": "https://github.com/laravel/mcp"
+            },
+            "time": "2026-03-12T12:46:43+00:00"
+        },
+        {
             "name": "laravel/pail",
             "version": "v1.2.6",
             "source": {
@@ -8714,6 +8853,67 @@
                 "source": "https://github.com/laravel/pint"
             },
             "time": "2026-03-12T15:51:39+00:00"
+        },
+        {
+            "name": "laravel/roster",
+            "version": "v0.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/roster.git",
+                "reference": "5089de7615f72f78e831590ff9d0435fed0102bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/roster/zipball/5089de7615f72f78e831590ff9d0435fed0102bb",
+                "reference": "5089de7615f72f78e831590ff9d0435fed0102bb",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "illuminate/routing": "^11.0|^12.0|^13.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2",
+                "symfony/yaml": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.14",
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^9.0|^10.0|^11.0",
+                "pestphp/pest": "^3.0|^4.1",
+                "phpstan/phpstan": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Roster\\RosterServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Roster\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Detect packages & approaches in use within a Laravel project",
+            "homepage": "https://github.com/laravel/roster",
+            "keywords": [
+                "dev",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/roster/issues",
+                "source": "https://github.com/laravel/roster"
+            },
+            "time": "2026-03-05T07:58:43+00:00"
         },
         {
             "name": "laravel/sail",

--- a/database/factories/ProjectFactory.php
+++ b/database/factories/ProjectFactory.php
@@ -19,10 +19,13 @@ class ProjectFactory extends Factory
     public function definition(): array
     {
         $title = fake()->sentence(3);
+
         return [
             'title' => $title,
-            'slug' => Str::slug($title) . '-' . fake()->unique()->regexify('[a-z0-9]{6}'),
-            'description' => ['en' => fake()->paragraphs(2, true)],
+            'slug' => Str::slug($title).'-'.fake()->unique()->regexify('[a-z0-9]{6}'),
+            'description' => [
+                ['type' => 'paragraph', 'data' => ['text' => '<p>'.fake()->paragraphs(2, true).'</p>']],
+            ],
             'project_url' => fake()->optional(0.7)->url(),
             'repo_url' => fake()->optional(0.5)->url(),
             'image' => fake()->optional(0.5)->imageUrl(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,6 @@
     "requires": true,
     "packages": {
         "": {
-            "dependencies": {
-                "alpinejs": "^3.15.8"
-            },
             "devDependencies": {
                 "@tailwindcss/vite": "^4.0.0",
                 "axios": "^1.11.0",
@@ -1136,30 +1133,6 @@
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@vue/reactivity": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
-            "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.1.5"
-            }
-        },
-        "node_modules/@vue/shared": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
-            "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
-            "license": "MIT"
-        },
-        "node_modules/alpinejs": {
-            "version": "3.15.8",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.8.tgz",
-            "integrity": "sha512-zxIfCRTBGvF1CCLIOMQOxAyBuqibxSEwS6Jm1a3HGA9rgrJVcjEWlwLcQTVGAWGS8YhAsTRLVrtQ5a5QT9bSSQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "~3.1.1"
-            }
         },
         "node_modules/ansi-regex": {
             "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,5 @@
         "tailwindcss": "^4.0.0",
         "vite": "^7.0.7"
     },
-    "dependencies": {
-        "alpinejs": "^3.15.8"
-    }
+    "dependencies": {}
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,4 +1,1 @@
 import './bootstrap';
-import Alpine from 'alpinejs';
-window.Alpine = Alpine;
-Alpine.start();

--- a/resources/views/components/ui/button.blade.php
+++ b/resources/views/components/ui/button.blade.php
@@ -1,5 +1,5 @@
 @if($isLink())
-    <a href="{{ $href }}" {{ $attributes->merge(['class' => $baseClasses() . ' ' . $variantClasses() . ' ' . $sizeClasses() . ' ' . $insetClasses() . ' gap-1.5 no-underline']) }}>
+    <a href="{{ $href }}" wire:navigate {{ $attributes->merge(['class' => $baseClasses() . ' ' . $variantClasses() . ' ' . $sizeClasses() . ' ' . $insetClasses() . ' gap-1.5 no-underline']) }}>
         @if($icon)
             {!! svg($icon, $iconSizeClasses() . ' shrink-0', ['aria-hidden' => 'true'])->toHtml() !!}
         @endif

--- a/resources/views/components/ui/link.blade.php
+++ b/resources/views/components/ui/link.blade.php
@@ -7,7 +7,7 @@
         {{ $slot }}
     </button>
 @else
-    <a href="{{ $href }}" @if($external) target="_blank" rel="noopener noreferrer" @else wire:navigate @endif {{ $merged }}>
+    <a href="{{ $renderedHref() }}" @if($isExternal()) target="_blank" rel="noopener noreferrer" @else wire:navigate @endif {{ $merged }}>
         {{ $slot }}
     </a>
 @endif

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -23,7 +23,9 @@
 
         @if($project->description !== null && $project->description !== [])
             <div class="mb-6 prose prose-zinc dark:prose-invert max-w-none">
-                @if(is_array($project->description))
+                @if(is_array($project->description) && \App\Support\PostContentSanitizer::isBuilderBlocks($project->description))
+                    {!! \App\Support\PostContentSanitizer::sanitize($project->description) !!}
+                @elseif(is_array($project->description))
                     @foreach($project->description as $block)
                         @if(is_string($block))
                             <p class="text-[13px] leading-[20px] text-zinc-700 dark:text-zinc-300 mb-3">{{ $block }}</p>


### PR DESCRIPTION
## Summary

Introduce Laravel Boost agents/skills and migrate posts/projects content to a richer, builder-based experience with safer rendering and better navigation behavior.

## What’s changed

- **Laravel Boost integration**
  - Add `laravel/boost` as a dev dependency and configure `boost.json` (agents, skills, Filament package).
  - Configure MCP servers in `.cursor/mcp.json` (Laravel Boost + Herd) to support local agent workflows.
  - Add Boost skills documentation for:
    - `pest-testing` (Pest 4 usage, patterns, and conventions).
    - `tailwindcss-development` (Tailwind v4 conventions, common patterns, and pitfalls).
  - Add `AGENTS.md` with Boost/agent guidelines (large doc).

- **Content builder for Posts & Projects**
  - Replace simple rich text / key-value descriptions with Filament Builder sections:
    - Posts: `content` becomes a Builder with `paragraph` and `image` blocks (RichEditor + FileUpload).
    - Projects: `description` becomes a Builder with `paragraph` and `image` blocks.
  - Make `slug` fields for Posts and Projects UI-only:
    - Disable manual editing, don’t dehydrate, generate default slug from title with helper text.

- **Model-level slug generation**
  - `Post` and `Project` models now generate unique slugs on `saving` when the slug is empty:
    - Base slug from the title.
    - Append `-n` suffix when a slug already exists, excluding the current record when updating.
  - Keep route model binding on `slug`.

- **Content sanitization & rendering**
  - Extend `PostContentSanitizer` to:
    - Detect Filament Builder blocks vs TipTap JSON.
    - Convert Builder `paragraph` and `image` blocks into safe HTML.
    - Resolve image paths via `Storage::url()` and add basic figure/figcaption markup.
  - Update project show view to:
    - Prefer Builder-aware rendering when `description` is in Builder format.
    - Fallback to the previous array-of-strings rendering path.

- **UI components & navigation**
  - `x-ui:link` component:
    - Allow `external` to be `null` and infer external vs internal using `app.url`.
    - Normalize same-origin absolute URLs to relative paths for internal links so `wire:navigate` can intercept them.
  - `x-ui:button` component:
    - Add `wire:navigate` to anchor variant so buttons behave as SPA navigation when acting as links.
    - Minor cleanup (`\in_array` usage).
  - Blade views:
    - Update button and link templates to use `renderedHref()` and `isExternal()` where appropriate.

- **Factories & frontend cleanup**
  - Update `ProjectFactory`:
    - Generate `slug` in a consistent format.
    - Seed `description` as a Builder-style paragraph block instead of simple localized text.
  - Remove Alpine from `package.json`/`app.js` and drop `package-lock.json` to simplify the JS surface (Tailwind + Vite only).

## Rationale

- Centralizes content structure (posts/projects) on Filament Builder for richer layouts and images while keeping the public output safe via `PostContentSanitizer`.
- Moves slug logic to the model layer for more predictable, unique, and DRY behavior, while simplifying the admin UI.
- Prepares the codebase for AI-assisted workflows (Boost/MCP/skills) around testing and Tailwind, improving DX for future iterations.
- Improves navigation UX by making internal links SPA-friendly (`wire:navigate`) and reliably detecting external links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added content builder support for posts and projects with paragraph and image blocks for richer formatting.
  * Implemented automatic slug generation from titles.
  * Enhanced link navigation with smart internal/external link handling.

* **Documentation**
  * Added Pest testing skill guide.
  * Added Tailwind CSS development skill guide.
  * Added comprehensive Laravel Boost guidelines and rules.

* **Refactor**
  * Removed Alpine.js dependency.
  * Restructured content field handling to support block-based editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->