### PR TITLE
Implement caching for landing and about pages with automatic invalidation

### DIFF
--- a/app/Http/Controllers/AboutController.php
+++ b/app/Http/Controllers/AboutController.php
@@ -9,7 +9,9 @@ class AboutController extends Controller
 {
     public function __invoke(): View
     {
-        $about = About::first();
+        $about = \Illuminate\Support\Facades\Cache::rememberForever('about_page', function () {
+            return About::first();
+        });
 
         return view('about', compact('about'));
     }

--- a/app/Http/Controllers/LandingController.php
+++ b/app/Http/Controllers/LandingController.php
@@ -10,8 +10,20 @@ class LandingController extends Controller
 {
     public function __invoke(): View
     {
-        $featuredProjects = Project::where('is_featured', true)->take(6)->get();
-        $latestPosts = Post::public()->latest()->take(3)->get();
+        $featuredProjects = \Illuminate\Support\Facades\Cache::remember('landing.featured_projects', now()->addHours(6), function () {
+            return Project::select(['id', 'title', 'slug', 'image'])
+                ->where('is_featured', true)
+                ->take(6)
+                ->get();
+        });
+
+        $latestPosts = \Illuminate\Support\Facades\Cache::remember('landing.latest_posts', now()->addHours(6), function () {
+            return Post::select(['id', 'title', 'slug'])
+                ->public()
+                ->latest()
+                ->take(3)
+                ->get();
+        });
 
         return view('landing', [
             'featuredProjects' => $featuredProjects,

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -9,7 +9,10 @@ class PostController extends Controller
 {
     public function index(): View
     {
-        $posts = Post::public()->latest()->paginate(10);
+        $posts = Post::select(['id', 'title', 'slug', 'created_at'])
+            ->public()
+            ->latest()
+            ->paginate(10);
 
         return view('posts.index', compact('posts'));
     }

--- a/app/Models/About.php
+++ b/app/Models/About.php
@@ -2,8 +2,11 @@
 
 namespace App\Models;
 
+use App\Observers\AboutObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Model;
 
+#[ObservedBy([AboutObserver::class])]
 class About extends Model
 {
     protected $table = 'about';

--- a/app/Observers/AboutObserver.php
+++ b/app/Observers/AboutObserver.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\About;
+use Illuminate\Support\Facades\Cache;
+
+class AboutObserver
+{
+    public function saved(About $about): void
+    {
+        Cache::forget('about_page');
+    }
+
+    public function deleted(About $about): void
+    {
+        Cache::forget('about_page');
+    }
+}

--- a/app/Observers/PostKnowledgeObserver.php
+++ b/app/Observers/PostKnowledgeObserver.php
@@ -9,11 +9,13 @@ class PostKnowledgeObserver
 {
     public function saved(Post $post): void
     {
+        \Illuminate\Support\Facades\Cache::forget('landing.latest_posts');
         SyncKnowledgeChunksJob::dispatch(Post::class, (int) $post->getKey());
     }
 
     public function deleted(Post $post): void
     {
+        \Illuminate\Support\Facades\Cache::forget('landing.latest_posts');
         SyncKnowledgeChunksJob::dispatch(Post::class, (int) $post->getKey());
     }
 }

--- a/app/Observers/ProjectKnowledgeObserver.php
+++ b/app/Observers/ProjectKnowledgeObserver.php
@@ -9,11 +9,13 @@ class ProjectKnowledgeObserver
 {
     public function saved(Project $project): void
     {
+        \Illuminate\Support\Facades\Cache::forget('landing.featured_projects');
         SyncKnowledgeChunksJob::dispatch(Project::class, (int) $project->getKey());
     }
 
     public function deleted(Project $project): void
     {
+        \Illuminate\Support\Facades\Cache::forget('landing.featured_projects');
         SyncKnowledgeChunksJob::dispatch(Project::class, (int) $project->getKey());
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -21,7 +21,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         // Force HTTPS in production
-        if (env('APP_ENV') === 'production') {
+        if (app()->isProduction()) {
             URL::forceScheme('https');
         }
     }


### PR DESCRIPTION
This PR introduces response caching for the landing and about pages to reduce database load and improve performance, along with automatic cache invalidation via model observers.

Key changes
- Add ‎`Cache::rememberForever('about_page', ...)` in ‎`AboutController` to cache the about page content.
- Add cached queries in ‎`LandingController`:
   - [X] `landing.featured_projects` (6 hours) with a narrowed ‎`select` on project fields.
   - [X] `landing.latest_posts` (6 hours) with a narrowed ‎`select` on post fields.
- Optimize ‎`PostController@index` by selecting only required columns for the posts listing.
- Register ‎`AboutObserver` on the ‎`About` model using the ‎`#[ObservedBy]` attribute.
- Introduce ‎`AboutObserver` to clear the ‎`about_page` cache on ‎`saved` and ‎`deleted`.
- Update ‎`PostKnowledgeObserver` and ‎`ProjectKnowledgeObserver` to clear ‎`landing.latest_posts` and ‎`landing.featured_projects` caches on ‎`saved` and ‎`deleted`.
- Refine ‎`AppServiceProvider::boot` to use ‎`app()->isProduction()` when forcing HTTPS.

Motivation
- Reduce repeated database queries for frequently accessed public pages.
- Ensure cached content stays fresh by tying invalidation directly to write operations on related models.
- Slightly optimize payload size by selecting only necessary columns for public listings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Implemented caching for the About page to reduce server load and improve page load speeds.
  * Added caching for featured projects and latest posts on the landing page with automatic expiration.
  * Optimized database queries to fetch only necessary data.
  * Cache automatically refreshes when content is updated or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->