### PR TITLE
🧹 Remove unused import 'Type' in ListPortfolioProjects

### DIFF
--- a/app/Ai/Tools/ListPortfolioProjects.php
+++ b/app/Ai/Tools/ListPortfolioProjects.php
@@ -5,7 +5,6 @@ namespace App\Ai\Tools;
 use App\Ai\Knowledge\PortfolioContentExtractor;
 use App\Models\Project;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
-use Illuminate\JsonSchema\Types\Type;
 use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
@@ -61,7 +60,7 @@ class ListPortfolioProjects implements Tool
      * laravel/ai only adds that block when the schema is non-empty (see laravel/ai#313); a minimal
      * required flag keeps the wire format valid until a released SDK fix.
      *
-     * @return array<string, Type>
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
      */
     public function schema(JsonSchema $schema): array
     {


### PR DESCRIPTION
🎯 **What:** Removed the unused `use Illuminate\JsonSchema\Types\Type;` statement from `app/Ai/Tools/ListPortfolioProjects.php`.
💡 **Why:** Improving code maintainability and readability by eliminating dead code.
✅ **Verification:**
- Confirmed the import was only used in a PHPDoc.
- Updated the PHPDoc to use the fully qualified class name `\Illuminate\JsonSchema\Types\Type`.
- Ran `php -l` to verify no syntax errors.
- Requested and received a positive code review.
✨ **Result:** Cleaned up the `use` statements in `ListPortfolioProjects.php` while maintaining documentation accuracy.

---
*PR created automatically by Jules for task [15077407875433210335](https://jules.google.com/task/15077407875433210335) started by @ProblematicToucan*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code organization and type annotations for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->