### PR TITLE
🧹 [code health improvement] Remove empty comment in AppServiceProvider

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,7 +12,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
     }
 
     /**


### PR DESCRIPTION
🎯 **What:** Removed an empty `//` comment from the `register` method in `app/Providers/AppServiceProvider.php`.
💡 **Why:** Empty comments in boilerplate code are unnecessary and removing them improves the maintainability and readability of the codebase.
✅ **Verification:** Manually verified the file content and performed a syntax check using `php -l`. Automated tests and formatting were skipped due to environment-specific limitations (missing dependencies and restricted internet access).
✨ **Result:** A cleaner `AppServiceProvider.php` file.

---
*PR created automatically by Jules for task [920799170774248758](https://jules.google.com/task/920799170774248758) started by @ProblematicToucan*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor code cleanup with no impact on functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->