### PR TITLE
🔒 [security fix] Prevent SQL injection in HasFullTextSearch

### DIFF
--- a/app/Models/Concerns/HasFullTextSearch.php
+++ b/app/Models/Concerns/HasFullTextSearch.php
@@ -71,8 +71,10 @@ trait HasFullTextSearch
                          ->orWhere('title', 'like', "%{$term}%"); // generic fallback
         }
 
+        $column = $query->getQuery()->getGrammar()->wrap($this->fullTextColumn);
+
         return $query->whereRaw(
-            "{$this->fullTextColumn} @@ websearch_to_tsquery(?, ?)",
+            "{$column} @@ websearch_to_tsquery(?, ?)",
             [$this->searchLanguage, $term]
         );
     }
@@ -95,8 +97,10 @@ trait HasFullTextSearch
             return $query; // Sorting by relevance doesn't apply cleanly in SQLite fallback
         }
 
+        $column = $query->getQuery()->getGrammar()->wrap($this->fullTextColumn);
+
         return $query->orderByRaw(
-            "ts_rank({$this->fullTextColumn}, websearch_to_tsquery(?, ?)) DESC",
+            "ts_rank({$column}, websearch_to_tsquery(?, ?)) DESC",
             [$this->searchLanguage, $term]
         );
     }
@@ -128,10 +132,12 @@ trait HasFullTextSearch
             return $query->where($column, 'like', "%{$term}%");
         }
 
-        // The <% operator means "term has a word_similarity match in the column text". 
+        $wrappedColumn = $query->getQuery()->getGrammar()->wrap($column);
+
+        // The <% operator means "term has a word_similarity match in the column text".
         // We override the default threshold dynamically per query.
-        return $query->whereRaw("? <% {$column}", [$term])
-                     ->whereRaw("word_similarity(?, {$column}) >= ?", [$term, $threshold]);
+        return $query->whereRaw("? <% {$wrappedColumn}", [$term])
+                     ->whereRaw("word_similarity(?, {$wrappedColumn}) >= ?", [$term, $threshold]);
     }
 
     /**
@@ -147,7 +153,9 @@ trait HasFullTextSearch
             return $query;
         }
 
+        $wrappedColumn = $query->getQuery()->getGrammar()->wrap($column);
+
         // word_similarity requires (search_term, document_text)
-        return $query->orderByRaw("word_similarity(?, {$column}) DESC", [$term]);
+        return $query->orderByRaw("word_similarity(?, {$wrappedColumn}) DESC", [$term]);
     }
 }


### PR DESCRIPTION
🎯 **What:** Fixed multiple SQL injection vulnerabilities in the `HasFullTextSearch` trait.
⚠️ **Risk:** Dynamic column names and properties (like `$fullTextColumn`) were being interpolated directly into raw SQL fragments. If these values were ever influenced by user input, it could lead to arbitrary SQL execution.
🛡️ **Solution:** Used the Laravel database grammar's `wrap()` method to safely escape all interpolated column identifiers. This ensures that identifiers are correctly quoted for PostgreSQL, preventing SQL injection while maintaining compatibility with valid column names.

---
*PR created automatically by Jules for task [14294245839888396251](https://jules.google.com/task/14294245839888396251) started by @ProblematicToucan*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database query handling for search and filtering operations to ensure proper escaping and consistent ordering of results across different database systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->